### PR TITLE
Dockerfile for repull – add install and run via docker (no go needed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:alpine AS builder
+RUN apk update && apk add --no-cache git
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY *.go ./
+# RUN go build .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w' .
+
+FROM scratch
+WORKDIR /
+COPY --from=builder /build/repull .
+ENTRYPOINT ["/repull"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:alpine AS builder
-RUN apk update && apk add --no-cache git
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download

--- a/README.md
+++ b/README.md
@@ -31,7 +31,22 @@ It will
 8. start the new container with the newest image available **preserving all configuration/startup options**
 9. repeat for all images passed in the arguments.
 
-### Usage
+## Install and Run from Docker Hub
+```
+ $ docker pull jdevelop/repull
+ $ docker run      \
+   -v /var/run/docker.sock:/var/run/docker.sock  \
+   -v $HOME/.docker/config.json:/.docker/config.json   \
+   jdevelop/repull CONTAINER_NAME
+```
+
+## Install and Run from Source (requires go)
+```
+$ go install github.com/jdevelop/repull
+$ repull -h
+```
+
+## Usage
 ```
 ./repull -h
 Usage of ./repull:


### PR DESCRIPTION
* add a docker file to allow users to install / run from docker
* updated readme with docker & golang install steps
* docker image is only 9.2MB

### Bugs / Issues
* the cli interface is clumsy needing docker socket & config.json mount.  

## Building
```
# build
docker build . -t jdevelop/repull
# test run
docker run      \
   -v /var/run/docker.sock:/var/run/docker.sock\
   -v $HOME/.docker/config.json:/.docker/config.json   \
   jdevelop/repull -h
# push to docker hub
docker push jdevelop/repull
```

## Testing
e2e
```
$  docker run      -v /var/run/docker.sock:/var/run/docker.sock  -v$HOME/.docker/config.json:/.docker/config.json   tonymet/repull watchtower
time="2021-08-29T18:50:48Z" level=info msg="using default tag: latest\n"
time="2021-08-29T18:50:49Z" level=info msg="received image id: sha256:3283e0b5be326d77ff4f4e8b7a91d46aaa1d511c74877b5a32f161548812d00c"
time="2021-08-29T18:50:49Z" level=info msg="started container 42c9e474d38b00abaeffb3290955de6520877f8df8561bbb372916c1fbc02509
```

#### check image size = 9.2MB
```
$ docker images |head
REPOSITORY              TAG           IMAGE ID       CREATED         SIZE
repull                  latest        dd34402d5857   17 hours ago    9.19MB

```
